### PR TITLE
Update and configure Spotless

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,20 @@
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+    dependencies {
+        if (JavaVersion.current() >= JavaVersion.VERSION_11) {
+            // Code formatting; defines targets "spotlessApply" and "spotlessCheck".
+            // https://github.com/diffplug/spotless/tags ; see tags starting "gradle/"
+            // Only works on JDK 11+.
+            classpath 'com.diffplug.spotless:spotless-plugin-gradle:6.18.0'
+        }
+    }
+}
+
 plugins {
 	id "java"
 	id "maven-publish"
-	id "com.diffplug.gradle.spotless" version "3.26.1"
-}
-
-repositories {
-	// Use 'jcenter' for resolving your dependencies.
-	// You can declare any Maven/Ivy/file repository here.
-	mavenLocal()
-	jcenter()
 }
 
 configurations {
@@ -19,7 +25,6 @@ configurations {
 }
 
 ext {
-
 	isJava8 = JavaVersion.current() == JavaVersion.VERSION_1_8
 	isJava11plus = JavaVersion.current() >= JavaVersion.VERSION_11
 
@@ -76,7 +81,6 @@ dependencies {
 	errorproneJavac "com.google.errorprone:javac:9+181-r4173-1"
 	// https://mvnrepository.com/artifact/org.yaml/snakeyaml
 	implementation 'org.yaml:snakeyaml:1.8'
-
 }
 
 sourceSets {
@@ -105,18 +109,30 @@ tasks.withType(JavaCompile).all {
 	options.compilerArgs.add("-Xlint:all")
 }
 
-spotless {
+if (isJava11plus) {
+    apply plugin: 'com.diffplug.spotless'
+    spotless {
 	java {
 		target "src/**/*.java", "tests/**/*.java"
 		googleJavaFormat().aosp()
 		removeUnusedImports()
+		importOrder('com', 'jdk', 'lib', 'lombok', 'org', 'java', 'javax')
+                formatAnnotations().addTypeAnnotation("Unique").addTypeAnnotation("Shared").addTypeAnnotation("Disappear").addTypeAnnotation("Bottom")
 	}
+	groovyGradle {
+                target '**/*.gradle'
+                greclipse()  // which formatter Spotless should use to format .gradle files.
+                indentWithSpaces(4)
+                trimTrailingWhitespace()
+                // endWithNewline() // Don't want to end empty files with a newline
+        }
 	format "misc", {
-		target "**/*.gradle", "**/.gitignore"
+		target '**/*.md', "**/.gitignore"
 		trimTrailingWhitespace()
 		indentWithTabs()
 		endWithNewline()
 	}
+    }
 }
 
 // Run `./gradlew publishToMavenLocal` to publish your checker to your local Maven repository.
@@ -142,7 +158,6 @@ publishing {
 }
 
 test {
-
 	if (!isJava8) {
 		jvmArgs += compilerArgsForRunningCF
 	}


### PR DESCRIPTION
@al3xliu You will need to run `./gradlew spotlessApply` to actually reformat the files.
If you prefer 8 spaces in `build.gradle` change that option from 4 to 8.
Let me know if too much other formatting changes.